### PR TITLE
Support building on stable rust

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(nll)]
-
 pub mod cond_stmt_base;
 pub mod config;
 pub mod defs;

--- a/fuzzer/Cargo.toml
+++ b/fuzzer/Cargo.toml
@@ -4,6 +4,9 @@ version = "1.0.0"
 authors = ["spinpx <spinpx@gmail.com>"]
 edition = "2018"
 
+[features]
+unstable = []
+
 [dependencies]
 clap = "2.32"
 log = "0.4"

--- a/fuzzer/src/lib.rs
+++ b/fuzzer/src/lib.rs
@@ -1,6 +1,5 @@
 #![feature(asm)]
 #![feature(core_intrinsics)]
-#![feature(duration_float)]
 
 #[macro_use]
 extern crate log;

--- a/fuzzer/src/lib.rs
+++ b/fuzzer/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(nll)]
 #![feature(asm)]
 #![feature(core_intrinsics)]
 #![feature(duration_float)]

--- a/fuzzer/src/lib.rs
+++ b/fuzzer/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(core_intrinsics)]
+#![cfg_attr(feature = "unstable", feature(core_intrinsics))]
 
 #[macro_use]
 extern crate log;

--- a/fuzzer/src/lib.rs
+++ b/fuzzer/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(asm)]
 #![feature(core_intrinsics)]
 
 #[macro_use]

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(thread_local)]
-
 pub mod ffds;
 pub mod len_label;
 pub mod logger;
@@ -14,7 +12,6 @@ pub type DfsanLabel = u32;
 extern "C" {
     fn dfsan_read_label(addr: *const i8, size: usize) -> DfsanLabel;
     static mut __angora_cond_cmpid: u32;
-    #[thread_local]
     static mut __angora_context: u32;
 // static __angora_tid: u32;
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(nll)]
 #![feature(thread_local)]
 
 pub mod ffds;

--- a/runtime_fast/src/lib.rs
+++ b/runtime_fast/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(nll)]
 #![feature(thread_local)]
 
 pub mod fast;

--- a/runtime_fast/src/lib.rs
+++ b/runtime_fast/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(thread_local)]
-
 pub mod fast;
 pub mod forkcli;
 pub mod shm_conds;

--- a/runtime_fast/src/shm_conds.rs
+++ b/runtime_fast/src/shm_conds.rs
@@ -8,13 +8,9 @@ use lazy_static::lazy_static;
 
 extern "C" {
     static mut __angora_cond_cmpid: u32;
-    #[thread_local]
     static mut __angora_prev_loc: u32;
-    #[thread_local]
     static mut __angora_context: u32;
-    // #[thread_local]
     // static __angora_tid: u32;
-    #[thread_local]
     static mut __angora_level: u32;
 }
 


### PR DESCRIPTION
This greatly simplifies building Angora for rust targets, see https://github.com/AngoraFuzzer/Angora/issues/10#issuecomment-450583741

A few of these are obvious, but:
 * I'm not sure if the unlikely optimization here is critical (I presume it is), so I left it in, but hid it behind an "unstable" feature flag. Sadly, support for flags behind workspaces seems to be rather unresolved at the moment, so the only way to enable this that I found is --all-features.
 * The extern "C" { #[thread_local] }s don't seem to line up with the definitions in angora-llvm-pass.so.cc, see https://github.com/AngoraFuzzer/Angora/issues/10#issuecomment-450584239 so I just dropped them. I presume this is wrong somehow, so can swap for (optional) calls into C functions to load them as appropriate, but I presume it may be performance-critical so wanted to check first.