### PR TITLE
Print warning when skipping a large seed

### DIFF
--- a/fuzzer/src/depot/sync.rs
+++ b/fuzzer/src/depot/sync.rs
@@ -26,6 +26,8 @@ pub fn sync_depot(executor: &mut Executor, running: Arc<AtomicBool>, dir: &Path)
                 if file_len < config::MAX_INPUT_LEN {
                     let buf = read_from_file(path);
                     executor.run_sync(&buf);
+                } else {
+                    warn!("Seed discarded, too long: {:?}", path);
                 }
             }
         }

--- a/fuzzer/src/fuzz_main.rs
+++ b/fuzzer/src/fuzz_main.rs
@@ -65,7 +65,9 @@ pub fn fuzz_main(
     depot::sync_depot(&mut executor, running.clone(), &depot.dirs.seeds_dir);
 
     if depot.empty() {
-        error!("Failed to find any branches during dry run.\nPlease ensure that the binary has been instrumented and/or input directory is populated. \nPlease ensure that seed directory - {:?} has any file.", depot.dirs.seeds_dir);
+        error!("Failed to find any branches during dry run.");
+        error!("Please ensure that the binary has been instrumented and/or input directory is populated.");
+        error!("Please ensure that seed directory - {:?} has any file.", depot.dirs.seeds_dir);
         panic!();
     }
 


### PR DESCRIPTION
The current implementation discards large seeds silently. The only feedback provided to the user is that the number of seeds considered does not match the number of files in the input directory. No indication about the reason why the seed was discarded is provided.

This pull request adds a warning message that informs the user whenever a seed is discarded because of its dimension so that the user can act accordingly: either change the configuration or reduce the size of the seed.

In addition, a multi-line error message was split to improve readability.