### PR TITLE
Fix shape inference for math operators

### DIFF
--- a/runtime/src/tag_set.rs
+++ b/runtime/src/tag_set.rs
@@ -217,11 +217,12 @@ impl TagSet {
             return;
         }
         let mut cur_lb = lb;
-        for _ in 0..len {
+        for _ in 0..(len - 1) {
+            cur_lb = self.nodes[cur_lb].parent;
+
             if cur_lb == ROOT {
                 return;
             }
-            cur_lb = self.nodes[cur_lb].parent;
         }
         if self.nodes[cur_lb].parent == ROOT {
             if self.nodes[cur_lb].seg.begin + len as u32 == self.nodes[lb].seg.end {


### PR DESCRIPTION
Supposing to have a label `lb`, corresponding to the bit vector `001111`, the path describing it on the tree could be as follows, with `lb` pointing to the node that contains `[5,6)`.
```
     [0,0)
     /
  [0,2)
   / \
...  [2,3)
        \
        [3,4)
           \
           [4,5)
              \
              [5,6)
```
Calling `infer_shape2(lb, 4)`, the function should be able to group bytes from 2 to 5 together. This, however, with the current implementation, does not happen. After some debugging, it appears that the `for` loop is moving the `cur_lb` one too many times and make it point to the root, instead of `[2, 3)`, when terminating the loop. This patch fixes that behavior and correctly groups the bytes, producing the following tree after the execution:
```
     [0,0)
     /
  [0,2)
   / \
...  [2,6)
        \
        [3,4)
           \
           [4,5)
              \
              [5,6)
```
If this is not the intended behavior, please let me know.