### PR TITLE
Fix build on Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ auto/
 /bin/
 obj-intel64/
 .DS_Store
+llvm_mode/version.config

--- a/build/build.sh
+++ b/build/build.sh
@@ -6,6 +6,8 @@ if ! [ -x "$(command -v llvm-config)"  ]; then
     ./build/install_llvm.sh
     export PATH=${HOME}/clang+llvm/bin:$PATH
     export LD_LIBRARY_PATH=${HOME}/clang+llvm/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+    export CC=clang
+    export CXX=clang++
 fi
 
 cargo build

--- a/llvm_mode/Makefile.common
+++ b/llvm_mode/Makefile.common
@@ -56,7 +56,8 @@ test_deps:
 	@echo "[*] Checking for working 'llvm-config'..."
 
 	@which $(LLVM_CONFIG) >/dev/null 2>&1 || ( echo "[-] Oops, can't find 'llvm-config'. Install clang or set \$$LLVM_CONFIG or \$$PATH beforehand."; echo "    (Sometimes, the binary will be named llvm-config-4 or something like that.)"; exit 1 )
-	@echo "#define LLVM_VERSION_MAJOR ${LLVM_VERSION_MAJOR}\n#define LLVM_VERSION_MINOR ${LLVM_VERSION_MINOR}\n" > ${ROOT_DIR}/version.config
+	@echo "#define LLVM_VERSION_MAJOR ${LLVM_VERSION_MAJOR}" > ${ROOT_DIR}/version.config
+	@echo "#define LLVM_VERSION_MINOR ${LLVM_VERSION_MINOR}" >> ${ROOT_DIR}/version.config
 
 ifeq "$(VALID_LLVM_VERSION)" "0"
 	@echo "[-] LLVM version is `${LLVM_CONFIG} --version`, please use LLVM 4.0.0 - 7.1.0"

--- a/llvm_mode/Makefile.common
+++ b/llvm_mode/Makefile.common
@@ -38,15 +38,6 @@ ifeq "$(shell uname)" "Darwin"
   CLANG_LFL += -Wl,-flat_namespace -Wl,-undefined,suppress
 endif
 
-# We were using llvm-config --bindir to get the location of clang, but
-# this seems to be busted on some distros, so using the one in $PATH is
-# probably better.
-
-ifeq "$(origin CC)" "default"
-  CC         = clang
-  CXX        = clang++
-endif
-
 LLVM_VERSION_MAJOR=`${LLVM_CONFIG} --version | cut -f1 -d.`
 LLVM_VERSION_MINOR=`${LLVM_CONFIG} --version | cut -f2 -d.`
 VALID_LLVM_VERSION=$(shell expr ${LLVM_VERSION_MAJOR} \>= 4 \& ${LLVM_VERSION_MAJOR} \<= 7)

--- a/llvm_mode/dfsan/Makefile
+++ b/llvm_mode/dfsan/Makefile
@@ -1,7 +1,4 @@
 PREFIX      ?= ../../bin/
-CC         = clang
-CXX        = clang++
-AR         = ar
 LLVM_CONFIG ?= llvm-config
 CXXFLAGS    += -std=c++14 -Wall -fpic -O3 -g
 

--- a/llvm_mode/io-func.c
+++ b/llvm_mode/io-func.c
@@ -6,6 +6,7 @@
 
 #include <assert.h>
 #include <fcntl.h>
+#include <stdarg.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>


### PR DESCRIPTION
The generation of `version.config` does not work on Linux since, by default, `echo` does not interpret backslash escapes. The same file should also not be recorded by the VCS, since it is generated during the build process.

The compilation of an LLVM pass should be made with the same compiler used to build LLVM itself. The build system should not force `clang` since most Linux distribution build LLVM using `g++` and thus `llvm-config --cxxflags` may be incompatible with `clang`. In that case, `g++` should be used for the pass as well.

The last commit adds `stdarg.h` since `va_list` is used without including the correct header.