### PR TITLE
Make parser parse to json

### DIFF
--- a/fuzzer/src/cond_stmt/cond_state.rs
+++ b/fuzzer/src/cond_stmt/cond_state.rs
@@ -1,8 +1,9 @@
 use crate::{cond_stmt::CondStmt, mut_input::offsets::*};
 use angora_common::{config, defs};
 use std;
+use serde_derive::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 pub enum CondState {
     Offset,
     OffsetOpt,

--- a/fuzzer/src/cond_stmt/cond_stmt.rs
+++ b/fuzzer/src/cond_stmt/cond_stmt.rs
@@ -2,8 +2,9 @@ use super::CondState;
 use crate::fuzz_type::FuzzType;
 use angora_common::{cond_stmt_base::CondStmtBase, defs, tag::TagSeg};
 use std::hash::{Hash, Hasher};
+use serde_derive::{Deserialize, Serialize};
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Deserialize, Serialize)]
 pub struct CondStmt {
     pub base: CondStmtBase,
     pub offsets: Vec<TagSeg>,

--- a/fuzzer/src/cond_stmt/mod.rs
+++ b/fuzzer/src/cond_stmt/mod.rs
@@ -1,5 +1,5 @@
 mod cond_state;
-mod cond_stmt;
+pub mod cond_stmt;
 mod output;
 mod shm_conds;
 

--- a/fuzzer/src/lib.rs
+++ b/fuzzer/src/lib.rs
@@ -6,7 +6,7 @@ extern crate log;
 extern crate derive_more;
 
 mod branches;
-mod cond_stmt;
+pub mod cond_stmt;
 mod depot;
 pub mod executor;
 mod mut_input;


### PR DESCRIPTION
Eventhough the provided parser file was very handy, the output of the parser with the json argument was not valid json, but Rust pretty print output.
I added a new option to also create json output.
The output formats now are:
 - line
 - json
 - json_real

I also added an extra option to specify if the file was in pin mode or not, but this is optional.