### PR TITLE
gen_library_abilist: more general regex for detecting shared libraries

### DIFF
--- a/tools/gen_library_abilist.sh
+++ b/tools/gen_library_abilist.sh
@@ -24,7 +24,7 @@ if [ "$NM" = "" ]; then
     exit 1
 fi
 
-echo "# $1" | grep 'so$'
+echo "# $1" | grep 'so[.0-9]*$'
 if [ $? -eq 0 ]
 then
     # echo "dynamic library.."


### PR DESCRIPTION
Sometimes shared libararies will have numerical extensions, in which case the current regex will fail.