### PR TITLE
Fix for ASAN holding memory in fork loop

### DIFF
--- a/runtime_fast/src/forkcli.rs
+++ b/runtime_fast/src/forkcli.rs
@@ -40,11 +40,7 @@ pub fn start_forkcli() {
                     return;
                 }
 
-                let mut pid_buf = vec![];
-                pid_buf
-                    .write_i32::<LittleEndian>(child_pid)
-                    .expect("Could not write to child.");
-                if socket.write(&pid_buf).is_err() {
+                if socket.write_i32::<LittleEndian>(child_pid).is_err() {
                     process::exit(1);
                 }
 
@@ -53,11 +49,7 @@ pub fn start_forkcli() {
                     process::exit(1);
                 }
 
-                let mut status_buf = vec![];
-                status_buf
-                    .write_i32::<LittleEndian>(status)
-                    .expect("Could not write to child.");
-                if socket.write(&status_buf).is_err() {
+                if socket.write_i32::<LittleEndian>(status).is_err() {
                     process::exit(1);
                 }
             }


### PR DESCRIPTION
I'm currently working with a fuzzer based on Angora and noticed that when fuzzing with a binary that has been sanitized with ASAN the performance of the fuzzer (wrt execution of the instrumented binary) would drop significantly over time. The issue lies with the allocation of the buffers that are used to write to the fuzzer as ASAN holds on to this memory until execution stops. Directly writing the data through the socket fixes this issue.