### PR TITLE
Fix up compiler warnings

### DIFF
--- a/llvm_mode/compiler/angora_clang.c
+++ b/llvm_mode/compiler/angora_clang.c
@@ -31,20 +31,20 @@
 #include <string.h>
 #include <unistd.h>
 
-static u8 *obj_path;       /* Path to runtime libraries         */
-static u8 **cc_params;     /* Parameters passed to the real CC  */
+static str *obj_path;       /* Path to runtime libraries         */
+static const str **cc_params;     /* Parameters passed to the real CC  */
 static u32 cc_par_cnt = 1; /* Param count, including argv0      */
 static u8 clang_type = CLANG_FAST_TYPE;
 static u8 is_cxx = 0;
 
 /* Try to find the runtime libraries. If that fails, abort. */
-static void find_obj(u8 *argv0) {
+static void find_obj(const str *argv0) {
 
-  u8 *slash, *tmp;
+  str *slash, *tmp;
   slash = strrchr(argv0, '/');
 
   if (slash) {
-    u8 *dir;
+    str *dir;
     *slash = 0;
     dir = ck_strdup(argv0);
     *slash = '/';
@@ -63,11 +63,11 @@ static void find_obj(u8 *argv0) {
   FATAL("Unable to find 'libAngoraPass.so'");
 }
 
-static void check_type(char *name) {
-  u8 *use_fast = getenv("USE_FAST");
-  u8 *use_dfsan = getenv("USE_DFSAN");
-  u8 *use_track = getenv("USE_TRACK");
-  u8 *use_pin = getenv("USE_PIN");
+static void check_type(const str *name) {
+  str *use_fast = getenv("USE_FAST");
+  str *use_dfsan = getenv("USE_DFSAN");
+  str *use_track = getenv("USE_TRACK");
+  str *use_pin = getenv("USE_PIN");
   if (use_fast) {
     clang_type = CLANG_FAST_TYPE;
   } else if (use_dfsan) {
@@ -86,9 +86,8 @@ static u8 check_if_assembler(u32 argc, const char **argv) {
   /* Check if a file with an assembler extension ("s" or "S") appears in argv */
 
   while (--argc) {
-    u8 *cur = *(++argv);
-
-    const u8 *ext = strrchr(cur, '.');
+    const str *cur = *(++argv);
+    const str *ext = strrchr(cur, '.');
     if (ext && (!strcmp(ext + 1, "s") || !strcmp(ext + 1, "S"))) {
       return 1;
     }
@@ -196,11 +195,11 @@ static void add_dfsan_pass() {
   }
 }
 
-static void edit_params(u32 argc, char **argv) {
+static void edit_params(u32 argc, const str **argv) {
 
   u8 fortify_set = 0, asan_set = 0, x_set = 0, maybe_linking = 1, bit_mode = 0;
   u8 maybe_assembler = 0;
-  u8 *name;
+  const str *name;
 
   cc_params = ck_alloc((argc + 128) * sizeof(u8 *));
 
@@ -212,11 +211,11 @@ static void edit_params(u32 argc, char **argv) {
   check_type(name);
 
   if (is_cxx) {
-    u8 *alt_cxx = getenv("ANGORA_CXX");
-    cc_params[0] = alt_cxx ? alt_cxx : (u8 *)"clang++";
+    const str *alt_cxx = getenv("ANGORA_CXX");
+    cc_params[0] = alt_cxx ? alt_cxx : "clang++";
   } else {
-    u8 *alt_cc = getenv("ANGORA_CC");
-    cc_params[0] = alt_cc ? alt_cc : (u8 *)"clang";
+    const str *alt_cc = getenv("ANGORA_CC");
+    cc_params[0] = alt_cc ? alt_cc : "clang";
   }
 
   maybe_assembler = check_if_assembler(argc, argv);
@@ -226,7 +225,7 @@ static void edit_params(u32 argc, char **argv) {
     maybe_linking = 0;
 
   while (--argc) {
-    u8 *cur = *(++argv);
+    const str *cur = *(++argv);
     // FIXME
     if (!strcmp(cur, "-O1") || !strcmp(cur, "-O2") || !strcmp(cur, "-O3")) {
       continue;
@@ -418,7 +417,7 @@ static void edit_params(u32 argc, char **argv) {
 
 /* Main entry point */
 
-int main(int argc, char **argv) {
+int main(int argc, const char **argv) {
 
   if (argc < 2) {
 

--- a/llvm_mode/external_lib/io_func.c
+++ b/llvm_mode/external_lib/io_func.c
@@ -516,6 +516,9 @@ int __dfsw_stat(const char *path, struct stat *buf, dfsan_label path_label,
   return ret;
 }
 
+int __xstat(int vers, const char* path, struct stat* buf);
+
+// int xstat(int vers, const char* path, struct stat* buf);
 DEFAULT_VISIBILITY
 int __dfsw___xstat(int vers, const char *path, struct stat *buf,
                    dfsan_label vers_label, dfsan_label path_label,
@@ -531,6 +534,8 @@ int __dfsw___xstat(int vers, const char *path, struct stat *buf,
   *ret_label = 0;
   return ret;
 }
+
+int __fstat(int fd, struct stat* buf);
 
 // int fstat(int fd, struct stat *buf);
 DEFAULT_VISIBILITY
@@ -548,6 +553,9 @@ int __dfsw_fstat(int fd, struct stat *buf, dfsan_label fd_label,
   return ret;
 }
 
+int __fxstat(int vers, int fd, struct stat *buf);
+
+// int fxstat(int vers, int fd, struct stat *buf);
 DEFAULT_VISIBILITY
 int __dfsw___fxstat(int vers, const int fd, struct stat *buf,
                     dfsan_label vers_label, dfsan_label fd_label,
@@ -580,6 +588,9 @@ int __dfsw_lstat(const char *path, struct stat *buf, dfsan_label path_label,
   return ret;
 }
 
+int __lxstat(int vers, const char* path, struct stat *buf);
+
+// int lxstat(int vers, const char* path, struct stat *buf);
 DEFAULT_VISIBILITY
 int __dfsw___lxstat(int vers, const char *path, struct stat *buf,
                     dfsan_label vers_label, dfsan_label path_label,

--- a/llvm_mode/external_lib/stdalloc.c
+++ b/llvm_mode/external_lib/stdalloc.c
@@ -122,12 +122,12 @@ __dfsw_realloc(void *ptr, size_t size, dfsan_label ptr_label,
       heapmap_invalidate(ptr);
 #endif
       const dfsan_label *old_label_area = dfsan_shadow_for(ptr);
-      dfsan_label *new_label_area = dfsan_shadow_for(ret);
+      const dfsan_label *new_label_area = dfsan_shadow_for(ret);
       // DEBUG_PRINTF("[+] Before memcpy: old label = %u, new label = %u\n",
       //     dfsan_read_label(ptr, old_size),
       //     dfsan_read_label(ret, new_size));
 
-      memcpy(new_label_area, old_label_area, sizeof(dfsan_label) * old_size);
+      memcpy((void*)new_label_area, old_label_area, sizeof(dfsan_label) * old_size);
 
       // DEBUG_PRINTF("[+] After memcpy: old label = %u, new label = %u\n",
       //     dfsan_read_label(ptr, old_size),

--- a/llvm_mode/include/alloc_inl.h
+++ b/llvm_mode/include/alloc_inl.h
@@ -35,12 +35,12 @@
 
 #define alloc_printf(_str...)                                                  \
   ({                                                                           \
-    u8 *_tmp;                                                                  \
+    str *_tmp;                                                                 \
     s32 _len = snprintf(NULL, 0, _str);                                        \
     if (_len < 0)                                                              \
       FATAL("Whoa, snprintf() fails?!");                                       \
     _tmp = ck_alloc(_len + 1);                                                 \
-    snprintf((char *)_tmp, _len + 1, _str);                                    \
+    snprintf((str *)_tmp, _len + 1, _str);                                     \
     _tmp;                                                                      \
   })
 
@@ -253,7 +253,7 @@ static inline void *DFL_ck_realloc_block(void *orig, u32 size) {
 
 /* Create a buffer with a copy of a string. Returns NULL for NULL inputs. */
 
-static inline u8 *DFL_ck_strdup(u8 *str) {
+static inline str *DFL_ck_strdup(const str *str) {
 
   void *ret;
   u32 size;
@@ -261,7 +261,7 @@ static inline u8 *DFL_ck_strdup(u8 *str) {
   if (!str)
     return NULL;
 
-  size = strlen((char *)str) + 1;
+  size = strlen(str) + 1;
 
   ALLOC_CHECK_SIZE(size);
   ret = malloc(size + ALLOC_OFF_TOTAL);

--- a/llvm_mode/include/defs.h
+++ b/llvm_mode/include/defs.h
@@ -65,6 +65,7 @@
 
 typedef uint32_t dfsan_label;
 
+typedef char str;
 typedef uint8_t u8;
 typedef uint16_t u16;
 typedef uint32_t u32;

--- a/runtime_fast/src/context.rs
+++ b/runtime_fast/src/context.rs
@@ -1,6 +1,6 @@
+#[link(name = "context", kind = "static")]
 extern "C" {
     #[cfg(not(any(feature = "unstable", test)))]
-    #[link(name = "context", kind = "static")]
     pub fn __angora_reset_context();
 }
 


### PR DESCRIPTION
* Correct signedness for c-strings in angora-clang
* Const-correctness throughout
* Move `#[link]` attribute to `extern` block

Fixes all warnings emitted by `clang` version 14.